### PR TITLE
change IntegrityError to DatabaseError

### DIFF
--- a/django_uidfield/misc.py
+++ b/django_uidfield/misc.py
@@ -2,6 +2,7 @@ import random
 import string
 
 from django.db import IntegrityError
+from django.db.utils import DatabaseError
 
 
 def new_uid(max_length, prefix=None,
@@ -28,6 +29,6 @@ def new_uid(max_length, prefix=None,
                 )
 
             return prefix + pure_uid
-        except IntegrityError:
+        except DatabaseError:
             if i >= max_generation_attempts:
                 raise

--- a/django_uidfield/models.py
+++ b/django_uidfield/models.py
@@ -1,4 +1,5 @@
 from django.db import models, IntegrityError, transaction
+from django.db.utils import DatabaseError
 
 from .fields import UIDField
 
@@ -21,7 +22,7 @@ class UIDModel(models.Model):
             try:
                 with transaction.atomic():
                     return super(UIDModel, self).save(*args, **kwargs)
-            except IntegrityError as e:
+            except DatabaseError as e:
                 uid_fields = self.uid_fields()
                 if not any(field.attname in str(e) for field in uid_fields):
                     raise


### PR DESCRIPTION
Sometimes, Django raises a DatabaseError instead of an IntegrityError when duplicates are found.

Reference [here](https://github.com/django/django/blob/03049fb8d96ccd1f1ed0285486103542de42faba/django/db/models/base.py#L817)