### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Pretty UID fields for your Django models, with customizable prefixes and control
 Usage
 -----
 
-See examples below. You can optionally inherit your models from `UIDModel`, which gracefully handles IntergrityError on saving UIDs, making up to 3 attempts with random UIDs. Integrity errors should be pretty rare if you use large enough `max_length` on your fields, but you may still want to use it for extra safety.
+See examples below. You can optionally inherit your models from `UIDModel`, which gracefully handles `IntegityError` on saving UIDs, making up to 3 attempts with random UIDs. Integrity errors should be pretty rare if you use large enough `max_length` on your fields, but you may still want to use it for extra safety.
 
 ```python
 from django_uidfield.fields import UIDField
@@ -18,7 +18,7 @@ from django_uidfield.fields import UIDField
 
 class YourModel(models.Model):
     uid_field = UIDField(prefix='tmp_', max_length=20)
-    
+
 # the value will be like 'tmp_Akw81LmtPqS93dKb'
 ```
 or


### PR DESCRIPTION
In addition to a typo in it, `IntegrityError` wasn't styled as code, unlike the other code objects referred to in the README. This will fix the spelling and make its display consistent with the rest of the file.