### PR TITLE
Alternative prefixes

### DIFF
--- a/django_uidfield/fields.py
+++ b/django_uidfield/fields.py
@@ -15,7 +15,7 @@ class UIDField(models.CharField):
         chars=string.ascii_letters + string.digits,
         alternative_prefixes=None,
         *args,
-        **kwargs,
+        **kwargs
     ):
         if alternative_prefixes is None:
             alternative_prefixes = []

--- a/django_uidfield/fields.py
+++ b/django_uidfield/fields.py
@@ -9,15 +9,24 @@ class UIDField(models.CharField):
     prefix = None
     chars = None
 
-    def __init__(self, prefix=None, chars=string.ascii_letters + string.digits,
-                 *args, **kwargs):
+    def __init__(
+        self,
+        prefix=None,
+        chars=string.ascii_letters + string.digits,
+        alternative_prefixes=None,
+        *args,
+        **kwargs,
+    ):
+        if alternative_prefixes is None:
+            alternative_prefixes = []
+        self.alternative_prefixes = alternative_prefixes
         self.prefix = prefix
         self.chars = chars
         super(UIDField, self).__init__(*args, **kwargs)
 
     @property
     def non_db_attrs(self):
-        return super().non_db_attrs + ('prefix', 'chars')
+        return super().non_db_attrs + ('prefix', 'chars', 'alternative_prefixes')
 
     def populate(self, model_instance, force_renew=False):
         uid = getattr(model_instance, self.attname, None)
@@ -36,5 +45,21 @@ class UIDField(models.CharField):
         name, path, args, kwargs = super().deconstruct()
         if self.prefix:
             kwargs['prefix'] = self.prefix
+        if self.alternative_prefixes:
+            kwargs['alternative_prefixes'] = self.alternative_prefixes
         kwargs['chars'] = self.chars
         return name, path, args, kwargs
+
+    def get_prep_value(self, value):
+        value = super().get_prep_value(value)
+
+        for alt_prefix in self.alternative_prefixes:
+            if not value.startswith(alt_prefix):
+                continue
+
+            prefix_length = len(alt_prefix)
+            _, data = value[:prefix_length], value[prefix_length:]
+            value = self.prefix + data
+            break
+
+        return value

--- a/django_uidfield/fields.py
+++ b/django_uidfield/fields.py
@@ -26,7 +26,11 @@ class UIDField(models.CharField):
 
     @property
     def non_db_attrs(self):
-        return super().non_db_attrs + ('prefix', 'chars', 'alternative_prefixes')
+        return super().non_db_attrs + (
+            'prefix',
+            'chars',
+            'alternative_prefixes',
+        )
 
     def populate(self, model_instance, force_renew=False):
         uid = getattr(model_instance, self.attname, None)

--- a/django_uidfield/tests.py
+++ b/django_uidfield/tests.py
@@ -87,7 +87,7 @@ class UIDFieldTest(CheckMixin, TestCase):
         obj = TestModel.objects.create()
 
         prefix_length = len(TestModel.uid_field.field.prefix)
-        prefix, data = obj.uid_field[:prefix_length], obj.uid_field[prefix_length:]
+        _, data = obj.uid_field[:prefix_length], obj.uid_field[prefix_length:]
 
         # We can use valid alternative prefixes to get our object
         for alt_prefix in ['alt_', 'other_']:

--- a/django_uidfield/tests.py
+++ b/django_uidfield/tests.py
@@ -86,7 +86,7 @@ class UIDFieldTest(CheckMixin, TestCase):
         """Test querying UIDField with alternative prefixes"""
         obj = TestModel.objects.create()
 
-        prefix_length = len(TestModel.uid_field.field.prefix)
+        prefix_length = len('tmp_')
         _, data = obj.uid_field[:prefix_length], obj.uid_field[prefix_length:]
 
         # We can use valid alternative prefixes to get our object


### PR DESCRIPTION
I don't consider this ready for merging. Could somebody look at this?

### Why would anybody need alternative prefixes?

Here's my example. I use `UIDField` together with graphene-django. It serves as an ID field for GraphQL, which is a very common scenario as far as I know 😉 .

I have a legacy GraphQL type that I want to rename. It was called ServiceType when we only sold services, but now that we also sell physical goods, I want to rename it to ItemType.

I cannot just rename the type, since it would break GraphQL fragments that use it. So I have to create a second type in parallel, then deprecate and phase out the old one.

These two types need to have different prefixes for `Node.from_global_id` to work, but if I try to use different prefixes, I need to write code that fixes the prefix before actually querying the DB. Similar code ends up in many places (resolvers, filters) and this make it hard to maintain. It would be nice to move this logic to a single place.

### Things that I would like feedback on

* I didn't really consider potential impact from this change. Is it going to break something?
* Does this feature belong here?